### PR TITLE
Don't apply a format if there was none specified.

### DIFF
--- a/StringType.cls
+++ b/StringType.cls
@@ -335,8 +335,11 @@ DateTimeFormatSpecifiers:
             
 ApplyStringFormat:
             'apply computed format string:
-            formattedValue = VBA.Strings.Format(v, thisFormat)
-            
+            If thisFormat = "" Then
+                formattedValue = v
+            Else
+                formattedValue = VBA.Strings.format(v, thisFormat)
+            End If
             
 AlignFormattedValue:
             'apply specified alignment specifier:


### PR DESCRIPTION
Using an empty format changes the value. E.g.:

    StringType.format("2 7", "") ' -> 27
    StringType.format("2.7", "") ' -> 27 (given "," is the decimal separator)

With this change this happens:

    StringType.format("2 7", "") ' -> 2 7
    StringType.format("2.7", "") ' -> 2.7
